### PR TITLE
My solution chapter2

### DIFF
--- a/src/Chapter2.hs
+++ b/src/Chapter2.hs
@@ -140,7 +140,7 @@ List of booleans:
 
 String is a list of characters:
 >>> :t "some string"
-"Some string" :: [Char]
+"some string" :: [Char]
 
 Empty list:
 >>> :t []
@@ -208,10 +208,8 @@ to guess first, what you will see.
 >>> drop 5 "Hello, World!"
 ", World!"
 >>> zip "abc" [1, 2, 3]  -- convert two lists to a single list of pairs
-zip :: [a] -> [b] -> [(a, b)]
 [('a',1),('b',2),('c',3)]
 >>> words "Hello   Haskell     World!"  -- split the string into the list of words
-words :: String -> [String]
 ["Hello","Haskell","World!"]
 
 
@@ -338,7 +336,9 @@ from it!
 ghci> :l src/Chapter2.hs
 -}
 subList :: Int -> Int -> [a] -> [a]
-subList first second list = drop first (take (second+1) list)
+subList first second list = if first < 0 || second < 0 
+  then []
+  else drop first (take (second+1) list)
 
 {- |
 =⚔️= Task 4
@@ -352,8 +352,8 @@ Implement a function that returns only the first half of a given list.
 -}
 firstHalf :: [a] -> [a]
 firstHalf l = 
-	let halfIndex = div (length l) 2 
-	in take halfIndex l
+  let halfIndex = div (length l) 2 
+  in take halfIndex l
 
 
 {- |
@@ -612,7 +612,7 @@ Implement a function that duplicates each element of the list
 -}
 duplicate :: [a] -> [a]
 duplicate [] = [] 
-duplicate (x:xs) = x : x : dublicate xs 
+duplicate (x:xs) = x : x : duplicate xs 
 
 
 {- |
@@ -634,8 +634,8 @@ takeEven l = go 1 l
     go :: Int -> [a] -> [a]
     go _ [] = []
     go acc (x:xs) = if mod acc 2 == 0 
-    	then go (acc+1) xs 
-	else x : go (acc+1) xs
+      then go (acc+1) xs 
+      else x : go (acc+1) xs
 
 {- |
 =🛡= Higher-order functions
@@ -755,8 +755,8 @@ the list with only those lists that contain a passed element.
 
 🕯 HINT: Use the 'elem' function to check whether an element belongs to a list
 -}
-contains :: a -> [[a]]
-contains e l = any (elem e) l 
+contains :: Int -> [[Int]] -> [[Int]]
+contains e l = filter (elem e) l
 
 
 {- |
@@ -798,10 +798,11 @@ mastered the skill of eta-reducing.
 divideTenBy :: Int -> Int
 divideTenBy = div 10
 
-listElementsLessThan :: a -> [a] -> [a]  
-listElementsLessThan x = filter (< x)
+listElementsLessThan :: Int -> [Int] -> [Int]  
+listElementsLessThan x = filter ( < x)
 
 -- Can you eta-reduce this one???
+pairMul :: [Int] -> [Int] -> [Int]
 pairMul = zipWith (*)
 
 {- |
@@ -857,9 +858,11 @@ list.
 
 🕯 HINT: Use the 'cycle' function
 -}
-import Data.List (cycle)
+
 rotate :: Int -> [a] -> [a]
-rotate num l = take (length l) (drop num (cycle l)) 
+rotate num l = if num < 0 
+  then []
+  else take (length l) (drop num (cycle l)) 
 
 {- |
 =💣= Task 12*

--- a/src/Chapter2.hs
+++ b/src/Chapter2.hs
@@ -338,7 +338,7 @@ ghci> :l src/Chapter2.hs
 subList :: Int -> Int -> [a] -> [a]
 subList first second list = if first < 0 || second < 0 
   then []
-  else drop first (take (second+1) list)
+  else drop first (take (second + 1) list)
 
 {- |
 =⚔️= Task 4
@@ -629,13 +629,12 @@ Write a function that takes elements of a list only on even positions.
 -}
 takeEven :: [a] -> [a]
 takeEven [] = []
-takeEven l = go 1 l
+takeEven l = go True l
   where
-    go :: Int -> [a] -> [a]
+    go :: Bool -> [a] -> [a]
     go _ [] = []
-    go acc (x:xs) = if mod acc 2 == 0 
-      then go (acc+1) xs 
-      else x : go (acc+1) xs
+    go True (x:xs) = x : go False xs
+    go False (_:xs) = go True xs 
 
 {- |
 =🛡= Higher-order functions
@@ -742,7 +741,7 @@ value of the element itself
 🕯 HINT: Use combination of 'map' and 'replicate'
 -}
 smartReplicate :: [Int] -> [Int]
-smartReplicate l = concat (map (\x->replicate x x) l) 
+smartReplicate = concatMap (\x->replicate x x) 
 
 {- |
 =⚔️= Task 9
@@ -756,7 +755,7 @@ the list with only those lists that contain a passed element.
 🕯 HINT: Use the 'elem' function to check whether an element belongs to a list
 -}
 contains :: Int -> [[Int]] -> [[Int]]
-contains e l = filter (elem e) l
+contains e = filter (elem e) 
 
 
 {- |
@@ -860,6 +859,7 @@ list.
 -}
 
 rotate :: Int -> [a] -> [a]
+rotate _ [] = []
 rotate num l = if num < 0 
   then []
   else take (length l) (drop num (cycle l)) 
@@ -879,10 +879,13 @@ and reverses it.
   cheating!
 -}
 
+-- copied from solution to understand
 rewind :: [a] -> [a]
-rewind [] = []
-rewind (x:xs) = rewind xs ++ [x]
-
+rewind = go []
+  where 
+    go :: [a] -> [a] -> [a]
+    go res [] = res
+    go res (x:xs) = go (x : res) xs
 
 {-
 You did it! Now it is time to the open pull request with your changes

--- a/src/Chapter2.hs
+++ b/src/Chapter2.hs
@@ -136,43 +136,43 @@ functions in GHCi and insert the corresponding resulting output below:
 
 List of booleans:
 >>> :t [True, False]
-
+[True, False] :: [Bool]
 
 String is a list of characters:
 >>> :t "some string"
-
+"Some string" :: [Char]
 
 Empty list:
 >>> :t []
-
+[] :: [a]
 
 Append two lists:
 >>> :t (++)
-
+(++) :: [a] -> [a] -> [a]
 
 Prepend an element at the beginning of a list:
 >>> :t (:)
-
+(:) :: a -> [a] -> [a]
 
 Reverse a list:
 >>> :t reverse
-
+reverse :: [a] -> [a]
 
 Take first N elements of a list:
 >>> :t take
-
+take :: Int -> [a] -> [a]
 
 Create list from N same elements:
 >>> :t replicate
-
+replicate :: Int -> a -> [a]
 
 Split a string by line breaks:
 >>> :t lines
-
+lines :: String -> [String]
 
 Join a list of strings with line breaks:
 >>> :t unlines
-
+unlines :: [String] -> String
 
 -}
 
@@ -186,31 +186,33 @@ Evaluate the following expressions in GHCi and insert the answers. Try
 to guess first, what you will see.
 
 >>> [10, 2] ++ [3, 1, 5]
-
+[10,2,3,1,5]
 >>> [] ++ [1, 4]  -- [] is an empty list
-
+[1,4]
 >>> 3 : [1, 2]
-
+[3,1,2]
 >>> 4 : 2 : [5, 10]  -- prepend multiple elements
-
+[4,2,5,10]
 >>> [1 .. 10]  -- list ranges
-
+[1,2,3,4,5,6,7,8,9,10]
 >>> [10 .. 1]
-
+[]
 >>> [10, 9 .. 1]  -- backwards list with explicit step
-
+[10,9,8,7,6,5,4,3,2,1]
 >>> length [4, 10, 5]  -- list length
-
+3
 >>> replicate 5 True
-
+[True,True,True,True,True]
 >>> take 5 "Hello, World!"
-
+"Hello"
 >>> drop 5 "Hello, World!"
-
+", World!"
 >>> zip "abc" [1, 2, 3]  -- convert two lists to a single list of pairs
-
+zip :: [a] -> [b] -> [(a, b)]
+[('a',1),('b',2),('c',3)]
 >>> words "Hello   Haskell     World!"  -- split the string into the list of words
-
+words :: String -> [String]
+["Hello","Haskell","World!"]
 
 
 👩‍🔬 Haskell has a lot of syntax sugar. In the case with lists, any
@@ -336,7 +338,7 @@ from it!
 ghci> :l src/Chapter2.hs
 -}
 subList :: Int -> Int -> [a] -> [a]
-subList = error "subList: Not implemented!"
+subList first second list = drop first (take (second+1) list)
 
 {- |
 =⚔️= Task 4
@@ -348,8 +350,10 @@ Implement a function that returns only the first half of a given list.
 >>> firstHalf "bca"
 "b"
 -}
--- PUT THE FUNCTION TYPE IN HERE
-firstHalf l = error "firstHalf: Not implemented!"
+firstHalf :: [a] -> [a]
+firstHalf l = 
+	let halfIndex = div (length l) 2 
+	in take halfIndex l
 
 
 {- |
@@ -500,7 +504,9 @@ True
 >>> isThird42 [42, 42, 0, 42]
 False
 -}
-isThird42 = error "isThird42: Not implemented!"
+isThird42 :: [Int] -> Bool
+isThird42 (_:_:42:_) = True
+isThird42 _ = False
 
 
 {- |
@@ -605,7 +611,8 @@ Implement a function that duplicates each element of the list
 
 -}
 duplicate :: [a] -> [a]
-duplicate = error "duplicate: Not implemented!"
+duplicate [] = [] 
+duplicate (x:xs) = x : x : dublicate xs 
 
 
 {- |
@@ -620,7 +627,15 @@ Write a function that takes elements of a list only on even positions.
 >>> takeEven [2, 1, 3, 5, 4]
 [2,3,4]
 -}
-takeEven = error "takeEven: Not implemented!"
+takeEven :: [a] -> [a]
+takeEven [] = []
+takeEven l = go 1 l
+  where
+    go :: Int -> [a] -> [a]
+    go _ [] = []
+    go acc (x:xs) = if mod acc 2 == 0 
+    	then go (acc+1) xs 
+	else x : go (acc+1) xs
 
 {- |
 =🛡= Higher-order functions
@@ -727,7 +742,7 @@ value of the element itself
 🕯 HINT: Use combination of 'map' and 'replicate'
 -}
 smartReplicate :: [Int] -> [Int]
-smartReplicate l = error "smartReplicate: Not implemented!"
+smartReplicate l = concat (map (\x->replicate x x) l) 
 
 {- |
 =⚔️= Task 9
@@ -740,7 +755,8 @@ the list with only those lists that contain a passed element.
 
 🕯 HINT: Use the 'elem' function to check whether an element belongs to a list
 -}
-contains = error "contains: Not implemented!"
+contains :: a -> [[a]]
+contains e l = any (elem e) l 
 
 
 {- |
@@ -780,13 +796,13 @@ Let's now try to eta-reduce some of the functions and ensure that we
 mastered the skill of eta-reducing.
 -}
 divideTenBy :: Int -> Int
-divideTenBy x = div 10 x
+divideTenBy = div 10
 
--- TODO: type ;)
-listElementsLessThan x l = filter (< x) l
+listElementsLessThan :: a -> [a] -> [a]  
+listElementsLessThan x = filter (< x)
 
 -- Can you eta-reduce this one???
-pairMul xs ys = zipWith (*) xs ys
+pairMul = zipWith (*)
 
 {- |
 =🛡= Lazy evaluation
@@ -841,7 +857,9 @@ list.
 
 🕯 HINT: Use the 'cycle' function
 -}
-rotate = error "rotate: Not implemented!"
+import Data.List (cycle)
+rotate :: Int -> [a] -> [a]
+rotate num l = take (length l) (drop num (cycle l)) 
 
 {- |
 =💣= Task 12*
@@ -857,7 +875,10 @@ and reverses it.
   function, but in this task, you need to implement it manually. No
   cheating!
 -}
-rewind = error "rewind: Not Implemented!"
+
+rewind :: [a] -> [a]
+rewind [] = []
+rewind (x:xs) = rewind xs ++ [x]
 
 
 {-


### PR DESCRIPTION
### Solutions for Chapter 2

cc @vrom911 @chshersh

Hi, I'm not fully understand why ghc didn't let me use this type annotation
```haskell
contains :: a -> [[a]] -> [[a]]
contains e l = filter (elem e) l
```
with this error
```
src/Chapter2.hs:759:24: error:
    • No instance for (Eq a) arising from a use of ‘elem’
      Possible fix:
        add (Eq a) to the context of
          the type signature for:
            contains :: forall a. a -> [[a]] -> [[a]]
    • In the first argument of ‘filter’, namely ‘(elem e)’
      In the expression: filter (elem e) l
      In an equation for ‘contains’: contains e l = filter (elem e) l
    |
759 | contains e l = filter (elem e) l
    |                        ^^^^^^
```